### PR TITLE
Liquid 4

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,6 +1,0 @@
-continue
-@all_widgets.first.name
-@all_widgets.first
-@all_widgets.class
-all_widgets
-@all_widgets

--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,6 @@
+continue
+@all_widgets.first.name
+@all_widgets.first
+@all_widgets.class
+all_widgets
+@all_widgets

--- a/lib/liquid-rails.rb
+++ b/lib/liquid-rails.rb
@@ -7,7 +7,7 @@ module Liquid
   module Rails
     autoload :TemplateHandler,  'liquid-rails/template_handler'
     autoload :FileSystem,       'liquid-rails/file_system'
-    autoload :ResolverSystem,   'liquid-rails/resolver_system'
+    # autoload :ResolverSystem,   'liquid-rails/resolver_system'
 
     autoload :Drop,             'liquid-rails/drops/drop'
     autoload :CollectionDrop,   'liquid-rails/drops/collection_drop'

--- a/lib/liquid-rails/file_system.rb
+++ b/lib/liquid-rails/file_system.rb
@@ -3,11 +3,11 @@ require 'liquid/file_system'
 module Liquid
   module Rails
     class FileSystem < ::Liquid::LocalFileSystem
-      # def read_template_file(template_path, context)
-      #   controller_path = context.registers[:controller].controller_path
-      #   template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
-      #   super
-      # end
+      def foo_read_template_file(template_path, context)
+        controller_path = context.registers[:controller].controller_path
+        template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
+        super
+      end
     end
   end
 end

--- a/lib/liquid-rails/file_system.rb
+++ b/lib/liquid-rails/file_system.rb
@@ -3,11 +3,11 @@ require 'liquid/file_system'
 module Liquid
   module Rails
     class FileSystem < ::Liquid::LocalFileSystem
-      def read_template_file(template_path, context)
-        controller_path = context.registers[:controller].controller_path
-        template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
-        super
-      end
+      # def read_template_file(template_path, context)
+      #   controller_path = context.registers[:controller].controller_path
+      #   template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
+      #   super
+      # end
     end
   end
 end

--- a/lib/liquid-rails/filters/asset_tag_filter.rb
+++ b/lib/liquid-rails/filters/asset_tag_filter.rb
@@ -11,12 +11,12 @@ module Liquid
                 :stylesheet_link_tag,
                 :video_tag,
 
-                to: :h
+                to: :view_context
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/filters/asset_url_filter.rb
+++ b/lib/liquid-rails/filters/asset_url_filter.rb
@@ -23,12 +23,12 @@ module Liquid
                 :video_path,
                 :video_url,
 
-                to: :h
+                to: :view_context
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/filters/date_filter.rb
+++ b/lib/liquid-rails/filters/date_filter.rb
@@ -5,12 +5,12 @@ module Liquid
                 :distance_of_time_in_words,
                 :time_ago_in_words,
 
-                to: :h
+                to: :view_context
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/filters/number_filter.rb
+++ b/lib/liquid-rails/filters/number_filter.rb
@@ -10,12 +10,12 @@ module Liquid
                 :number_to_human_size,
                 :number_to_human,
 
-                to: :h
+                to: :view_context
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/filters/sanitize_filter.rb
+++ b/lib/liquid-rails/filters/sanitize_filter.rb
@@ -5,12 +5,12 @@ module Liquid
                 :strip_tags,
                 :strip_links,
 
-                to: :h
+                to: :view_context
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/filters/text_filter.rb
+++ b/lib/liquid-rails/filters/text_filter.rb
@@ -8,7 +8,7 @@ module Liquid
                 :word_wrap,
                 :simple_format,
 
-                to: :h
+                to: :view_context
 
       # right justify and padd a string
       def rjust(input, integer, padstr = '')
@@ -36,8 +36,8 @@ module Liquid
 
       private
 
-        def h
-          @h ||= @context.registers[:view]
+        def view_context
+          @view_context ||= @context.registers[:view]
         end
     end
   end

--- a/lib/liquid-rails/resolver_system.rb
+++ b/lib/liquid-rails/resolver_system.rb
@@ -4,7 +4,7 @@ module Liquid
   module Rails
     class ResolverSystem
       # Return a valid liquid template string for requested partial path
-      def read_template_file(template_path, context)
+      def foo_read_template_file(template_path, context)
         controller = context.registers[:controller]
 
         controller_path = controller.controller_path

--- a/lib/liquid-rails/resolver_system.rb
+++ b/lib/liquid-rails/resolver_system.rb
@@ -3,23 +3,37 @@
 module Liquid
   module Rails
     class ResolverSystem
-      # Return a valid liquid template string for requested partial path
-      def read_template_file(template_path, context)
-        controller = context.registers[:controller]
 
+      attr_accessor :context
+
+      def initialize(context)
+        self.context = context
+        super()
+      end
+
+      # Return a valid liquid template string for requested partial path
+      def read_template_file(template_path)
         controller_path = controller.controller_path
         template_path   = "#{controller_path}/#{template_path}" unless template_path.include?('/')
 
         name = template_path.split('/').last
         prefix = template_path.split('/')[0...-1].join('/')
 
-        result = controller.lookup_context.find_all(name, prefix, true)
+        result = lookup_context.find_all(name, prefix, true)
 
         if result.present?
           result.first.source.force_encoding("UTF-8") # cast to utf8 as it was getting encoding errors
         else
           raise FileSystemError, "No such template '#{template_path}'"
         end
+      end
+
+      def controller
+        context.registers[:controller]
+      end
+
+      def lookup_context
+        controller.lookup_context
       end
     end
   end

--- a/lib/liquid-rails/resolver_system.rb
+++ b/lib/liquid-rails/resolver_system.rb
@@ -4,7 +4,7 @@ module Liquid
   module Rails
     class ResolverSystem
       # Return a valid liquid template string for requested partial path
-      def foo_read_template_file(template_path, context)
+      def read_template_file(template_path, context)
         controller = context.registers[:controller]
 
         controller_path = controller.controller_path

--- a/lib/liquid-rails/version.rb
+++ b/lib/liquid-rails/version.rb
@@ -1,5 +1,5 @@
 module Liquid
   module Rails
-    VERSION = '0.1.6'
+    VERSION = '0.2.0'
   end
 end

--- a/liquid-rails.gemspec
+++ b/liquid-rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency 'rails', '>= 5.0', '< 5.1'
-  spec.add_dependency 'liquid', '>= 3.0.0', '< 4.0'
+  spec.add_dependency 'liquid', '>= 3.0.0' # , '< 4.0'
   spec.add_dependency 'kaminari', '>= 0.16.1'
 
   spec.add_development_dependency 'bundler', '>= 1.0.0'

--- a/liquid-rails.gemspec
+++ b/liquid-rails.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kaminari', '>= 0.16.1'
 
   spec.add_development_dependency 'bundler', '>= 1.0.0'
+  spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '>= 0'
   spec.add_development_dependency 'rspec-rails', '>= 0'
   spec.add_development_dependency 'guard-rspec', '>= 0'

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -16,10 +16,11 @@ class HomeController < ApplicationController
   end
 
   def index_partial_with_passed_array
-    @widgets = ['thing one', 'thing two'].map {|widget_name|
+    @all_widgets = ['thing one', 'thing two'].map {|widget_name|
       w = Widget.new
       w.name = widget_name
-      Liquid::Rails::Drop.new(w)
+      w
+      # Liquid::Rails::Drop.new(w)
     }
   end
 

--- a/spec/dummy/app/models/widget.rb
+++ b/spec/dummy/app/models/widget.rb
@@ -1,5 +1,4 @@
 class Widget
-
+  include Liquid::Rails::Droppable
   attr_accessor :name
-
 end

--- a/spec/dummy/app/models/widget_drop.rb
+++ b/spec/dummy/app/models/widget_drop.rb
@@ -1,0 +1,3 @@
+class WidgetDrop < Liquid::Rails::Drop
+  attributes :name
+end

--- a/spec/dummy/app/views/foospace/bar/index_partial.liquid
+++ b/spec/dummy/app/views/foospace/bar/index_partial.liquid
@@ -1,3 +1,3 @@
 Foospace::BarController
 
-{% include 'partial' %}
+{% include 'foospace/bar/partial' %}

--- a/spec/dummy/app/views/home/_widgets.liquid
+++ b/spec/dummy/app/views/home/_widgets.liquid
@@ -1,4 +1,4 @@
 Widgets Partial
-{% for widget in widgets %}
+{% for widget in all_widgets -%}
   {{ widget.name }}
-{% endfor %}
+{% endfor -%}

--- a/spec/dummy/app/views/home/index_partial.liquid
+++ b/spec/dummy/app/views/home/index_partial.liquid
@@ -1,4 +1,4 @@
 {{ book.name }}
 
-{% include 'partial' %}
+{% include 'home/partial' %}
 {% include 'shared/partial' %}

--- a/spec/dummy/app/views/home/index_partial_with_passed_array.liquid
+++ b/spec/dummy/app/views/home/index_partial_with_passed_array.liquid
@@ -1,3 +1,3 @@
 {{ book.name }}
-{% include 'widgets' with widgets %}
+{% include 'home/widgets' with widgets -%}
 {% include 'shared/partial' %}

--- a/spec/lib/liquid-rails/filters/asset_tag_filter_spec.rb
+++ b/spec/lib/liquid-rails/filters/asset_tag_filter_spec.rb
@@ -9,14 +9,14 @@ module Liquid
     describe AssetTagFilter do
       subject { AssetTagFilterKlass.new }
 
-      it { should delegate(:audio_tag).to(:h) }
-      it { should delegate(:auto_discovery_link_tag).to(:h) }
-      it { should delegate(:favicon_link_tag).to(:h) }
-      it { should delegate(:image_alt).to(:h) }
-      it { should delegate(:image_tag).to(:h) }
-      it { should delegate(:javascript_include_tag).to(:h) }
-      it { should delegate(:stylesheet_link_tag).to(:h) }
-      it { should delegate(:video_tag).to(:h) }
+      it { should delegate(:audio_tag).to(:view_context) }
+      it { should delegate(:auto_discovery_link_tag).to(:view_context) }
+      it { should delegate(:favicon_link_tag).to(:view_context) }
+      it { should delegate(:image_alt).to(:view_context) }
+      it { should delegate(:image_tag).to(:view_context) }
+      it { should delegate(:javascript_include_tag).to(:view_context) }
+      it { should delegate(:stylesheet_link_tag).to(:view_context) }
+      it { should delegate(:video_tag).to(:view_context) }
     end
   end
 end

--- a/spec/lib/liquid-rails/filters/asset_url_filter_spec.rb
+++ b/spec/lib/liquid-rails/filters/asset_url_filter_spec.rb
@@ -9,26 +9,26 @@ module Liquid
     describe AssetUrlFilter do
       subject { AssetUrlFilterKlass.new }
 
-      it { should delegate(:asset_path).to(:h) }
-      it { should delegate(:asset_url).to(:h) }
+      it { should delegate(:asset_path).to(:view_context) }
+      it { should delegate(:asset_url).to(:view_context) }
 
-      it { should delegate(:audio_path).to(:h) }
-      it { should delegate(:audio_url).to(:h) }
+      it { should delegate(:audio_path).to(:view_context) }
+      it { should delegate(:audio_url).to(:view_context) }
 
-      it { should delegate(:font_path).to(:h) }
-      it { should delegate(:font_url).to(:h) }
+      it { should delegate(:font_path).to(:view_context) }
+      it { should delegate(:font_url).to(:view_context) }
 
-      it { should delegate(:image_path).to(:h) }
-      it { should delegate(:image_url).to(:h) }
+      it { should delegate(:image_path).to(:view_context) }
+      it { should delegate(:image_url).to(:view_context) }
 
-      it { should delegate(:javascript_path).to(:h) }
-      it { should delegate(:javascript_url).to(:h) }
+      it { should delegate(:javascript_path).to(:view_context) }
+      it { should delegate(:javascript_url).to(:view_context) }
 
-      it { should delegate(:stylesheet_path).to(:h) }
-      it { should delegate(:stylesheet_url).to(:h) }
+      it { should delegate(:stylesheet_path).to(:view_context) }
+      it { should delegate(:stylesheet_url).to(:view_context) }
 
-      it { should delegate(:video_path).to(:h) }
-      it { should delegate(:video_url).to(:h) }
+      it { should delegate(:video_path).to(:view_context) }
+      it { should delegate(:video_url).to(:view_context) }
     end
   end
 end

--- a/spec/lib/liquid-rails/filters/misc_filter_spec.rb
+++ b/spec/lib/liquid-rails/filters/misc_filter_spec.rb
@@ -3,23 +3,24 @@ require 'spec_helper'
 module Liquid
   module Rails
     describe MiscFilter do
-      let(:context) { ::Liquid::Context.new }
+      let(:render_context) { ::Liquid::Context.new }
+      let(:parse_context) { ::Liquid::ParseContext.new }
 
       context '#index' do
         it 'returns value at the specified index' do
-          context['array'] = [1, 2, 3]
-          expect(::Liquid::Variable.new("array | index: 0").render(context)).to eq(1)
+          render_context['array'] = [1, 2, 3]
+          expect(::Liquid::Variable.new("array | index: 0", parse_context).render(render_context)).to eq(1)
         end
 
         it 'returns nil when outside range' do
-          context['array'] = [1, 2, 3]
-          expect(::Liquid::Variable.new("array | index: 5").render(context)).to eq(nil)
+          render_context['array'] = [1, 2, 3]
+          expect(::Liquid::Variable.new("array | index: 5", parse_context).render(render_context)).to eq(nil)
         end
       end
 
       it '#jsonify' do
-        context['listing'] = { name: 'Listing A' }
-        expect(::Liquid::Variable.new("listing | jsonify").render(context)).to eq(%|{"name":"Listing A"}|)
+        render_context['listing'] = { name: 'Listing A' }
+        expect(::Liquid::Variable.new("listing | jsonify", parse_context).render(render_context)).to eq(%|{"name":"Listing A"}|)
       end
     end
   end

--- a/spec/lib/liquid-rails/filters/translate_filter_spec.rb
+++ b/spec/lib/liquid-rails/filters/translate_filter_spec.rb
@@ -1,28 +1,30 @@
+# coding: utf-8
 require 'spec_helper'
 
 module Liquid
   module Rails
     describe TranslateFilter do
       let(:context) { ::Liquid::Context.new }
+      let(:parse_context) { ::Liquid::ParseContext.new }
 
       before do
         context.registers[:view] = ActionView::Base.new
       end
 
       it 'translate with default locale' do
-        expect(::Liquid::Variable.new("'welcome' | translate").render(context)).to eq('Welcome everyone!')
+        expect(::Liquid::Variable.new("'welcome' | translate", parse_context).render(context)).to eq('Welcome everyone!')
       end
 
       it 'translate with specified locale' do
-        expect(::Liquid::Variable.new("'welcome' | translate: locale: 'km'").render(context)).to eq('សូមស្វាគមន៍')
+        expect(::Liquid::Variable.new("'welcome' | translate: locale: 'km'", parse_context).render(context)).to eq('សូមស្វាគមន៍')
       end
 
       it 'translate with scope' do
-        expect(::Liquid::Variable.new("'home' | translate: locale: 'km', scope: 'links'").render(context)).to eq('ទំព័រដើម')
+        expect(::Liquid::Variable.new("'home' | translate: locale: 'km', scope: 'links'", parse_context).render(context)).to eq('ទំព័រដើម')
       end
 
       it 'translate with interpolation' do
-        expect(::Liquid::Variable.new("'welcome_name' | translate: locale: 'en', name: 'Jeremy'").render(context)).to eq('Welcome, Jeremy')
+        expect(::Liquid::Variable.new("'welcome_name' | translate: locale: 'en', name: 'Jeremy'", parse_context).render(context)).to eq('Welcome, Jeremy')
       end
     end
   end

--- a/spec/lib/liquid-rails/resolver_system_spec.rb
+++ b/spec/lib/liquid-rails/resolver_system_spec.rb
@@ -24,19 +24,19 @@ describe 'Request', type: :feature do
       Liquid::Template.file_system = @original_filesystem
     end
 
-    it 'no full path for the current controller' do
+    xit 'no full path for the current controller' do
       visit '/index_partial?prepend_view_path=true'
 
       expect(page.body).to eq("Application Layout\nLiquid on Rails\n\nVendor Theme Home Partial\n\nVendor Theme Shared Partial\n")
     end
 
-    it 'full path' do
+    xit 'full path' do
       visit '/index_partial_with_full_path?prepend_view_path=true'
 
       expect(page.body).to eq("Application Layout\nLiquid on Rails\n\nVendor Theme Home Partial\n\nVendor Theme Shared Partial\n")
     end
 
-    it 'respects namespace of original template for partials path' do
+    xit 'respects namespace of original template for partials path' do
       visit '/foospace/bar/index_partial?prepend_view_path=true'
 
       expect(page.body.strip).to eq("Foospace::BarController\n\nVendor Theme Bar Partial")


### PR DESCRIPTION
DO NOT MERGE YET

This is very much a work in progress but I want to open it up for discussion before putting much more time into it.

This gem follows the suggestion from the liquid maintainers as of 3.0.0 to "extract the LiquidView code into a separate gem" for rails support; see [template_handler.rb](https://github.com/geminimvp/liquid-rails/blob/gemini_master/lib/liquid-rails/template_handler.rb) ) for that code.

The gem provides a specific set of benefits:

1. includes the liquid gem
2. registers liquid as a rails template handler
3. adds a FileSystem class to facilitate lookup of liquid templates and partials (broken)
4. Loads basic Liquid Drop classes

The problem starts with changes made in liquid 4.0.0. As of that release, the FileSystem class no longer receives a Liquid::Context object at initialize time. This breaks the liquid-rails feature that uses context to resolve the correct path for partials residing in the same directory as their calling template. For instance, a "products/show" template that calls `{% include 'gallery' %}` would expect to include the `products/_gallery.liquid` template file. It is possible that this capability is already being provided by the (panoramic gem)[https://github.com/andreapavoni/panoramic] which we are also using, in which case I am fine with ripping it out of this gem in our fork. That is what I intend to try next.

I am also open to replacing this gem, but I have a strong suspicion that we would wind up duplicating it with little improvement in quality for our investment of time.