### PR TITLE
Fix failing specs on TemplateHandler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'liquid', github: 'geminimvp/liquid', branch: '30_include_with_array'
 # Specify your gem's dependencies in liquid-rails.gemspec
 gemspec

--- a/lib/liquid-rails/drops/drop.rb
+++ b/lib/liquid-rails/drops/drop.rb
@@ -89,7 +89,7 @@ module Liquid
       end
 
       def attributes
-        @attributes ||= self.class._attributes.dup.each_with_object({}) do |name, hash|
+        @attributes ||= self.class._attributes.to_a.dup.each_with_object({}) do |name, hash|
           hash[name.to_s] = send(name)
         end
       end

--- a/spec/dummy/app/controllers/home_controller.rb
+++ b/spec/dummy/app/controllers/home_controller.rb
@@ -17,9 +17,9 @@ class HomeController < ApplicationController
 
   def index_partial_with_passed_array
     @widgets = ['thing one', 'thing two'].map {|widget_name|
-      w = Widget.new
-      w.name = widget_name
-      Liquid::Rails::Drop.new(w)
+      Widget.new.tap { |w|
+        w.name = widget_name
+      }
     }
   end
 

--- a/spec/dummy/app/models/widget.rb
+++ b/spec/dummy/app/models/widget.rb
@@ -1,5 +1,4 @@
 class Widget
-
+  include Liquid::Rails::Droppable
   attr_accessor :name
-
 end

--- a/spec/dummy/app/models/widget_drop.rb
+++ b/spec/dummy/app/models/widget_drop.rb
@@ -1,0 +1,3 @@
+class WidgetDrop < Liquid::Rails::Drop
+  attributes :name
+end

--- a/spec/lib/liquid-rails/template_handler_spec.rb
+++ b/spec/lib/liquid-rails/template_handler_spec.rb
@@ -45,7 +45,7 @@ describe 'Request', type: :feature do
     it 'renders partial with passed-in array' do
       visit '/index_partial_with_passed_array'
 
-      expect(page.body).to eq("Application Layout\nLiquid on Rails\nWidgets Partial\nthing one\nthing two\nShared Partial")
+      expect(page.body).to eq("Application Layout\nLiquid on Rails\nWidgets Partial\n\n  thing one\n\n  thing two\n\nShared Partial")
     end
   end
 


### PR DESCRIPTION
I'm not sure exactly when, but we have accumulated some failing specs
that need to be corrected before we merge any new features.
* the Drop class was unable to proceed if a Drop had no
attributes (which is the case for the base Drop class under test)
* The {% for %} tag exhibited the undocumented behavior when passed an
array, which is fixed by referring to my own fork of liquid.
* Liquid 3.0.0 does not have whitespace control, so the spec is modified
to account for expected whitespace.
* I added a Drop class to the dummy app, since it did not seem to behave
properly without explicitly making the Widget#name attribute visible.